### PR TITLE
Use fullmatch instead of match

### DIFF
--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -54,7 +54,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         return VersionRange()
 
     # Tilde range
-    m = TILDE_CONSTRAINT.match(constraint)
+    m = TILDE_CONSTRAINT.fullmatch(constraint)
     if m:
         version = Version.parse(m.group(1))
 
@@ -67,7 +67,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         )
 
     # PEP 440 Tilde range (~=)
-    m = TILDE_PEP440_CONSTRAINT.match(constraint)
+    m = TILDE_PEP440_CONSTRAINT.fullmatch(constraint)
     if m:
         precision = 1
         if m.group(3):
@@ -90,7 +90,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         )
 
     # Caret range
-    m = CARET_CONSTRAINT.match(constraint)
+    m = CARET_CONSTRAINT.fullmatch(constraint)
     if m:
         version = Version.parse(m.group(1))
 
@@ -102,7 +102,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         )
 
     # X Range
-    m = X_CONSTRAINT.match(constraint)
+    m = X_CONSTRAINT.fullmatch(constraint)
     if m:
         op = m.group(1)
         major = int(m.group(2))
@@ -136,7 +136,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         return result
 
     # Basic comparator
-    m = BASIC_CONSTRAINT.match(constraint)
+    m = BASIC_CONSTRAINT.fullmatch(constraint)
     if m:
         op = m.group(1)
         version = m.group(2)

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -54,7 +54,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         return VersionRange()
 
     # Tilde range
-    m = TILDE_CONSTRAINT.fullmatch(constraint)
+    m = TILDE_CONSTRAINT.match(constraint)
     if m:
         version = Version.parse(m.group(1))
 
@@ -67,7 +67,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         )
 
     # PEP 440 Tilde range (~=)
-    m = TILDE_PEP440_CONSTRAINT.fullmatch(constraint)
+    m = TILDE_PEP440_CONSTRAINT.match(constraint)
     if m:
         precision = 1
         if m.group(3):
@@ -90,7 +90,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         )
 
     # Caret range
-    m = CARET_CONSTRAINT.fullmatch(constraint)
+    m = CARET_CONSTRAINT.match(constraint)
     if m:
         version = Version.parse(m.group(1))
 
@@ -102,7 +102,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         )
 
     # X Range
-    m = X_CONSTRAINT.fullmatch(constraint)
+    m = X_CONSTRAINT.match(constraint)
     if m:
         op = m.group(1)
         major = int(m.group(2))
@@ -136,7 +136,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         return result
 
     # Basic comparator
-    m = BASIC_CONSTRAINT.fullmatch(constraint)
+    m = BASIC_CONSTRAINT.match(constraint)
     if m:
         op = m.group(1)
         version = m.group(2)

--- a/semver/patterns.py
+++ b/semver/patterns.py
@@ -11,12 +11,12 @@ _COMPLETE_VERSION = r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?{}(?:\+[^\s]+)?
     MODIFIERS
 )
 
-COMPLETE_VERSION = re.compile("(?i)" + _COMPLETE_VERSION)
+COMPLETE_VERSION = re.compile("(?i)" + _COMPLETE_VERSION + "$")
 
 CARET_CONSTRAINT = re.compile(r"(?i)^\^({})$".format(_COMPLETE_VERSION))
 TILDE_CONSTRAINT = re.compile("(?i)^~(?!=)({})$".format(_COMPLETE_VERSION))
 TILDE_PEP440_CONSTRAINT = re.compile("(?i)^~=({})$".format(_COMPLETE_VERSION))
 X_CONSTRAINT = re.compile(r"^(!=|==)?\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.[xX*])+$")
 BASIC_CONSTRAINT = re.compile(
-    r"(?i)^(<>|!=|>=?|<=?|==?)?\s*({}|dev)".format(_COMPLETE_VERSION)
+    r"(?i)^(<>|!=|>=?|<=?|==?)?\s*({}|dev)$".format(_COMPLETE_VERSION)
 )


### PR DESCRIPTION
Using match only matches the beginning of the string and can ignore some version information.

I've encountered this problem with this version string '0.7.1dev1+1.\*' where not using fullmatch would ignore the '.\*' part.