### PR TITLE
Fix compatible prerelease clause (~=7.0.0rc1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
 

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -78,11 +78,11 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
 
         version = Version.parse(m.group(1))
 
+        low = version
+        
         if precision == 2:
-            low = version
             high = version.stable.next_major
         else:
-            low = Version(version.major, version.minor, version.patch)
             high = version.stable.next_minor
 
         return VersionRange(

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -79,7 +79,7 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         version = Version.parse(m.group(1))
 
         low = version
-        
+
         if precision == 2:
             high = version.stable.next_major
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,11 +16,18 @@ from semver import parse_constraint
         ("x.X.x.*", VersionRange()),
         # ('!=1.0.0', Constraint('!=', '1.0.0.0')),
         (">1.0.0", VersionRange(min=Version(1, 0, 0))),
+        (">1.0.0rc1", VersionRange(min=Version(1, 0, 0, pre="rc1"))),
         ("<1.2.3", VersionRange(max=Version(1, 2, 3))),
+        ("<1.2.3rc1", VersionRange(max=Version(1, 2, 3, pre="rc1"))),
         ("<=1.2.3", VersionRange(max=Version(1, 2, 3), include_max=True)),
+        ("<=1.2.3rc1", VersionRange(max=Version(1, 2, 3, pre="rc1"), include_max=True)),
+        ("<=1.2rc1", VersionRange(max=Version(1, 2, 0, pre="rc1"), include_max=True)),
         (">=1.2.3", VersionRange(min=Version(1, 2, 3), include_min=True)),
+        (">=1.2.3rc1", VersionRange(min=Version(1, 2, 3, pre="rc1"), include_min=True)),
         ("=1.2.3", Version(1, 2, 3)),
+        ("=1.2.3rc1", Version(1, 2, 3, pre="rc1")),
         ("1.2.3", Version(1, 2, 3)),
+        ("1.2.3rc1", Version(1, 2, 3, pre="rc1")),
         ("=1.0", Version(1, 0, 0)),
         ("1.2.3b5", Version(1, 2, 3, pre="b5")),
         (">= 1.2.3", VersionRange(min=Version(1, 2, 3), include_min=True)),
@@ -68,6 +75,14 @@ def test_parse_constraint_wildcard(input, constraint):
         ("~3.5", VersionRange(Version(3, 5, 0), Version(3, 6, 0), True)),
         ("~=3.5", VersionRange(Version(3, 5, 0), Version(4, 0, 0), True)),  # PEP 440
         ("~=3.5.3", VersionRange(Version(3, 5, 3), Version(3, 6, 0), True)),  # PEP 440
+        (
+            "~=3.5.3rc1",
+            VersionRange(Version(3, 5, 3, pre="rc1"), Version(3, 6, 0), True),
+        ),  # PEP 440
+        (
+            "~=3.5rc1",
+            VersionRange(Version(3, 5, pre="rc1"), Version(4, 0, 0), True),
+        ),  # PEP 440
     ],
 )
 def test_parse_constraint_tilde(input, constraint):


### PR DESCRIPTION
Before this change the prerelease `rc1` in e.g. `~=7.0.0rc1` would be lost on the low end:

```pycon
>>> vrange = parse_single_constraint('~=7.0.0rc1')
>>> vrange.min
<Version 7.0.0>
```

After:

```pycon
>>> vrange = parse_single_constraint('~=7.0.0rc1')
>>> vrange.min
<Version 7.0.0rc1>
```